### PR TITLE
Add start options for merge and force

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ For example, create the following file `src/main/resources/elasticsearch/twitter
 }
 ```
 
+By default, Beyonder will not overwrite an index if it already exists.
+This can be overridden by setting `force` to `true` in the expanded factory method
+`ElasticsearchBeyonder.start()`.
+
 Managing types
 --------------
 
@@ -196,6 +200,10 @@ For example, create the following file `src/main/resources/elasticsearch/twitter
   }
 }
 ```
+
+By default, Beyonder will attempt to merge defined mappings with existing ones.
+This can be overridden by setting `merge` to `false` in the expanded factory method
+`ElasticsearchBeyonder.start()`.
 
 Managing templates
 ------------------
@@ -225,6 +233,9 @@ in your project:
 }
 ```
 
+By default, Beyonder will not overwrite a template if it already exists.
+This can be overridden by setting `force` to `true` in the expanded factory method
+`ElasticsearchBeyonder.start()`.
 
 Why this name?
 ==============

--- a/src/main/java/fr/pilato/elasticsearch/tools/ElasticsearchBeyonder.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/ElasticsearchBeyonder.java
@@ -91,11 +91,20 @@ public class ElasticsearchBeyonder {
 	 * @throws Exception when beyonder can not start
 	 */
 	public static void start(RestClient client, String root) throws Exception {
-		logger.info("starting automatic settings/mappings discovery");
+		start(client, root, Defaults.MergeMappings, Defaults.ForceCreation);
+	}
 
-		// TODO make it a parameter
-		boolean merge = true;
-		boolean force = false;
+	/**
+	 * Automatically scan classpath and create indices, mappings, templates, and other settings.
+	 * @param client elasticsearch client
+	 * @param root dir within the classpath
+	 * @param merge whether or not to merge mappings
+	 * @param force whether or not to force creation of indices and templates
+	 * @throws Exception when beyonder can not start
+	 * @since 6.1
+	 */
+	public static void start(RestClient client, String root, boolean merge, boolean force) throws Exception {
+		logger.info("starting automatic settings/mappings discovery");
 
 		// create templates
 		List<String> templateNames = TemplateFinder.findTemplates(root);
@@ -144,8 +153,8 @@ public class ElasticsearchBeyonder {
 		logger.info("starting automatic settings/mappings discovery");
 
 		// TODO make it a parameter
-		boolean merge = true;
-		boolean force = false;
+		boolean merge = Defaults.MergeMappings;
+		boolean force = Defaults.ForceCreation;
 
 		// create templates
 		List<String> templateNames = TemplateFinder.findTemplates(root);

--- a/src/main/java/fr/pilato/elasticsearch/tools/SettingsFinder.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/SettingsFinder.java
@@ -46,6 +46,16 @@ public class SettingsFinder {
 		public static String IndexSettingsFileName = "_settings.json";
 		public static String UpdateIndexSettingsFileName = "_update_settings.json";
 		public static String TemplateDir = "_template";
+
+		/**
+		 * Default setting of whether or not to merge mappings on start.
+		 */
+		public static boolean MergeMappings = true;
+
+		/**
+		 * Default setting of whether or not to force creation of indices and templates on start.
+		 */
+		public static boolean ForceCreation = false;
 	}
 
 	/**

--- a/src/test/resources/models/forceenabled/twitter/tweet.json
+++ b/src/test/resources/models/forceenabled/twitter/tweet.json
@@ -1,0 +1,10 @@
+{
+  "tweet": {
+    "properties": {
+      "language": {
+        "type": "keyword",
+        "store": true
+      }
+    }
+  }
+}

--- a/src/test/resources/models/mergedisabled/twitter/tweet.json
+++ b/src/test/resources/models/mergedisabled/twitter/tweet.json
@@ -1,0 +1,10 @@
+{
+  "tweet": {
+    "properties": {
+      "language": {
+        "type": "keyword",
+        "store": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
This exposes the merge mappings and force creation settings into a new
ElasticsearchBeyonder.start() method along with adding default values to
the Defaults class.

Note that this idea came to me and @divideby0 while developing a benchmarking application. We generally like to clear out indices in between runs (especially when switching between scenarios which may have completely different mappings, settings, etc.). I noticed you left a TODO comment here, so I've gone ahead and implemented it on the `RestClient` version as the other version is marked for removal eventually.