### PR TITLE
Disable x-pack tests for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Versions
 
 | elasticsearch-beyonder  | elasticsearch | Release date |
 |:-----------------------:|:-------------:|:------------:|
-| 6.0-SNAPSHOT            | 5.x, 6.x      |              |
+| 6.3-SNAPSHOT            | 5.x, 6.x      |              |
 | 5.1                     | 5.x, 6.x      |  2017-07-12  |
 | 5.0                     | 5.x, 6.x      |  2017-07-11  |
 | 2.1.0                   | 2.0, 2.1      |  2015-11-25  |
@@ -282,16 +282,10 @@ mvn clean install -DskipIntegTests
 ```
 
 Integration tests can be ran against a cluster secured by [x-pack](https://www.elastic.co/downloads/x-pack).
-You have to activate as well the `es-xpack` profile:
+You have to activate as well the `es-xpack` profile (not supported yet):
 
 ```sh
 mvn clean install -Pes-xpack
-```
-
-Or if you want to run x-pack with a given elasticsearch version:
-
-```sh
-mvn clean install -Pes-6x -Pes-xpack
 ```
 
 If you wish to run integration tests against a cluster which is already running externally, you can configure the
@@ -329,7 +323,7 @@ License
 
 This software is licensed under the Apache 2 license, quoted below.
 
-	Copyright 2011-2017 David Pilato
+	Copyright 2011-2018 David Pilato
 	
 	Licensed under the Apache License, Version 2.0 (the "License"); you may not
 	use this file except in compliance with the License. You may obtain a copy of

--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,7 @@ when an elasticsearch client starts.
                     <artifactId>elasticsearch-maven-plugin</artifactId>
                     <version>6.6</version>
                     <configuration>
+                        <flavor>oss</flavor>
                         <version>${test.elasticsearch.version}</version>
                         <httpPort>${tests.cluster.rest.port}</httpPort>
                         <transportPort>${tests.cluster.transport.port}</transportPort>
@@ -357,44 +358,11 @@ when an elasticsearch client starts.
             <id>es-xpack</id>
             <build>
                 <plugins>
-                    <!-- Copy dependencies into lib folder -->
-                    <!-- To see full classpath use  mvn dependency:build-classpath -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <version>3.1.1</version>
-                        <executions>
-                            <execution>
-                                <id>integ-setup-dependencies-plugins</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>copy</goal>
-                                </goals>
-                                <configuration>
-                                    <skip>${skipIntegTests}</skip>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>org.elasticsearch.plugin</groupId>
-                                            <artifactId>${elasticsearch.security.artifact}</artifactId>
-                                            <version>${elasticsearch.security.version}</version>
-                                            <type>zip</type>
-                                        </artifactItem>
-                                    </artifactItems>
-                                    <useBaseVersion>true</useBaseVersion>
-                                    <outputDirectory>${project.build.directory}/integration-tests/plugins</outputDirectory>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <plugin>
                         <groupId>com.github.alexcojocaru</groupId>
                         <artifactId>elasticsearch-maven-plugin</artifactId>
                         <configuration>
-                            <plugins>
-                                <plugin>
-                                    <uri>file://${project.build.directory}/integration-tests/plugins/x-pack-${elasticsearch.security.version}.zip</uri>
-                                </plugin>
-                            </plugins>
+                            <flavour>default</flavour>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -410,6 +378,9 @@ when an elasticsearch client starts.
                     <plugin>
                         <groupId>com.github.alexcojocaru</groupId>
                         <artifactId>elasticsearch-maven-plugin</artifactId>
+                        <configuration>
+                            <flavour>oss</flavour>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
https://github.com/alexcojocaru/elasticsearch-maven-plugin does not support testing with another version than oss flavour.

We need to disable x-pack for now.