### PR TITLE
Add support for update mapping

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,9 +3,7 @@
 
 name: Build Pull Requests
 
-on:
-  push:
-    branches: [ master ]
+on: [pull_request]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -155,17 +155,16 @@ settings for your `twitter` index.
 
 For example, create the following file `src/main/resources/elasticsearch/twitter/_settings.json` in your project:
 
-```javascript
+```json
 {
   "settings": {
     "number_of_shards": 3,
-    "number_of_replicas": 2
+    "number_of_replicas": 0
   },
   "mappings": {
     "properties": {
-      "message": {
-        "type": "text"
-      }
+      "message": { "type": "text" },
+      "foo": { "type": "text" }
     }
   }
 }
@@ -174,6 +173,36 @@ For example, create the following file `src/main/resources/elasticsearch/twitter
 By default, Beyonder will not overwrite an index if it already exists.
 This can be overridden by setting `force` to `true` in the expanded factory method
 `ElasticsearchBeyonder.start()`.
+
+You can also provide a file named `_update_settings.json` to update your index settings 
+and a file named `_update_mapping.json` if you want to update an existing mapping. 
+Note that Elasticsearch do not allow updating all settings and mappings.
+
+You can for example add a new field, or change the `search_analyzer` for a given field but you can not modify
+the field `type`.
+
+Considering the previous example we saw, you can create a `elasticsearch/twitter/_update_settings.json` to update the
+number of replicas:
+
+```json
+{
+    "number_of_replicas" : 1
+}
+```
+
+And you can create `elasticsearch/twitter/_update_mapping.json`:
+
+```json
+{
+  "properties": {
+    "message" : {"type" : "text", "search_analyzer": "keyword" },
+    "bar" : { "type" : "text" }
+  }
+}
+```
+
+This will change the `search_analyzer` for the `message` field and will add a new field named `bar`.
+All other existing fields (like `foo` in the previous example) won't be changed.
 
 Managing templates
 ------------------
@@ -184,7 +213,7 @@ For example, if you planned to have indexes per year for twitter feeds (twitter2
 to define a template named `twitter_template`, you can add a file named `elasticsearch/_template/twitter_template.json`
 in your project:
 
-```javascript
+```json
 {
     "template" : "twitter*",
     "settings" : {
@@ -213,7 +242,7 @@ documents are being indexed. Please note that this feature is only supported whe
 For example, setting one fields value based on another field by using an Set Processor you an add a file named `elasticsearch/_pipeline/set_field_processor`
 in your project:
 
-```javascript
+```json
 {
   "description" : "Twitter pipeline",
   "processors" : [

--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@ when an elasticsearch client starts.
         <!-- For integration tests using Docker or external cluster -->
         <integ.elasticsearch.image>docker.elastic.co/elasticsearch/elasticsearch</integ.elasticsearch.image>
         <integ.elasticsearch.version>${elasticsearch.version}</integ.elasticsearch.version>
-        <tests.cluster.rest.port>9400</tests.cluster.rest.port>
-        <tests.cluster.transport.port>9500</tests.cluster.transport.port>
+        <tests.cluster.rest.port>9200</tests.cluster.rest.port>
+        <tests.cluster.transport.port>9300</tests.cluster.transport.port>
 
         <skipTests>false</skipTests>
         <skipUnitTests>${skipTests}</skipUnitTests>

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,12 @@ when an elasticsearch client starts.
             <artifactId>commons-text</artifactId>
             <version>1.9</version>
         </dependency>
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.9.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/fr/pilato/elasticsearch/tools/ElasticsearchBeyonder.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/ElasticsearchBeyonder.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static fr.pilato.elasticsearch.tools.index.IndexElasticsearchUpdater.createIndex;
+import static fr.pilato.elasticsearch.tools.index.IndexElasticsearchUpdater.updateMapping;
 import static fr.pilato.elasticsearch.tools.index.IndexElasticsearchUpdater.updateSettings;
 import static fr.pilato.elasticsearch.tools.template.TemplateElasticsearchUpdater.createTemplate;
 import static fr.pilato.elasticsearch.tools.pipeline.PipelineElasticsearchUpdater.createPipeline;
@@ -122,6 +123,7 @@ public class ElasticsearchBeyonder {
 		for (String indexName : indexNames) {
 			createIndex(client, root, indexName, force);
 			updateSettings(client, root, indexName);
+			updateMapping(client, root, indexName);
 		}
 		logger.info("start done. Rock & roll!");
 	}
@@ -165,6 +167,7 @@ public class ElasticsearchBeyonder {
 		for (String indexName : indexNames) {
 			createIndex(client, root, indexName, force);
 			updateSettings(client, root, indexName);
+			updateMapping(client, root, indexName);
 		}
 		logger.info("start done. Rock & roll!");
 	}

--- a/src/main/java/fr/pilato/elasticsearch/tools/ResourceList.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/ResourceList.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -88,7 +89,7 @@ public class ResourceList {
                         // remove leading slash that is not part of the JarEntry::getName
                         .substring(1);
             Set<String> result = new HashSet<>(); //avoid duplicates in case it is a subdirectory
-            try (JarFile jar = new JarFile(URLDecoder.decode(jarPath, "UTF-8"))) {
+            try (JarFile jar = new JarFile(URLDecoder.decode(jarPath, StandardCharsets.UTF_8))) {
                 Enumeration<JarEntry> entries = jar.entries(); //gives ALL entries in jar
                 while(entries.hasMoreElements()) {
                     String name = entries.nextElement().getName();

--- a/src/main/java/fr/pilato/elasticsearch/tools/SettingsFinder.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/SettingsFinder.java
@@ -19,22 +19,7 @@
 
 package fr.pilato.elasticsearch.tools;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
-
-import static java.nio.file.FileVisitResult.CONTINUE;
-
 public class SettingsFinder {
-
-	private static final Logger logger = LoggerFactory.getLogger(SettingsFinder.class);
 
 	public static class Defaults {
 		/**
@@ -45,6 +30,7 @@ public class SettingsFinder {
 		public static String JsonFileExtension = ".json";
 		public static String IndexSettingsFileName = "_settings.json";
 		public static String UpdateIndexSettingsFileName = "_update_settings.json";
+		public static String UpdateIndexMappingFileName = "_update_mapping.json";
 		public static String TemplateDir = "_template";
 		public static String PipelineDir = "_pipeline";
 
@@ -57,45 +43,5 @@ public class SettingsFinder {
 		 * Default setting of whether or not to force creation of indices and templates on start.
 		 */
 		public static boolean ForceCreation = false;
-	}
-
-	/**
-	 * Find all types within an index
-	 * @param root dir within the classpath
-	 * @param subdir subdir name
-     * @return A list of found JSON files
-     * @deprecated Sounds like it's not used. We will remove it
-     * @throws IOException if something goes wrong
-	 */
-	@Deprecated
-	protected static ArrayList<String> findJsonFiles(Path root, String subdir) throws IOException {
-		logger.debug("Looking for json files in classpath under [{}/{}].", root, subdir);
-
-		final ArrayList<String> jsonFiles = new ArrayList<>();
-		final Path indexDir = root.resolve(subdir);
-		if (Files.exists(indexDir)) {
-			Files.walkFileTree(indexDir, new SimpleFileVisitor<Path>() {
-				@Override
-				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-					// We have now files. They could be type, settings, templates...
-					String jsonFile = indexDir.relativize(file).toString();
-
-					if (jsonFile.equals(Defaults.IndexSettingsFileName) ||
-							jsonFile.equals(Defaults.UpdateIndexSettingsFileName)) {
-						logger.trace("ignoring: [{}]", jsonFile);
-						return CONTINUE;
-					}
-					jsonFile = jsonFile.substring(0, jsonFile.lastIndexOf(Defaults.JsonFileExtension));
-
-					jsonFiles.add(jsonFile);
-					logger.trace("json found: [{}]", jsonFile);
-					return CONTINUE;
-				}
-			});
-		} else {
-			logger.trace("[{}] does not exist in [{}].", subdir, root);
-		}
-
-		return jsonFiles;
 	}
 }

--- a/src/main/java/fr/pilato/elasticsearch/tools/index/IndexElasticsearchUpdater.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/index/IndexElasticsearchUpdater.java
@@ -164,6 +164,28 @@ public class IndexElasticsearchUpdater {
 	}
 
 	/**
+	 * Update mapping in Elasticsearch
+	 * @param client Elasticsearch client
+	 * @param index Index name
+	 * @param mapping Mapping if any, null if no update mapping
+	 */
+	@Deprecated
+	private static void updateMappingInElasticsearch(Client client, String index, String mapping) {
+		logger.trace("updateMapping([{}])", index);
+
+		assert client != null;
+		assert index != null;
+
+		if (mapping != null) {
+			logger.trace("Found update mapping for index [{}]: [{}]", index, mapping);
+			logger.debug("updating mapping for index [{}]", index);
+			client.admin().indices().preparePutMapping(index).setType("_doc").setSource(mapping, XContentType.JSON).get();
+		}
+
+		logger.trace("/updateMapping([{}])", index);
+	}
+
+	/**
 	 * Check if an index already exists
 	 * @param client Elasticsearch client
 	 * @param index Index name
@@ -197,6 +219,30 @@ public class IndexElasticsearchUpdater {
 	public static void updateSettings(Client client, String index) throws Exception {
 		String settings = IndexSettingsReader.readUpdateSettings(index);
 		updateIndexWithSettingsInElasticsearch(client, index, settings);
+	}
+
+
+	/**
+	 * Update index mapping in Elasticsearch. Read also _update_mapping.json if exists.
+	 * @param client Elasticsearch client
+	 * @param root dir within the classpath
+	 * @param index Index name
+	 */
+	@Deprecated
+	public static void updateMapping(Client client, String root, String index) {
+		String mapping = IndexSettingsReader.readUpdateMapping(root, index);
+		updateMappingInElasticsearch(client, index, mapping);
+	}
+
+	/**
+	 * Update index mapping in Elasticsearch. Read also _update_mapping.json if exists in default classpath dir.
+	 * @param client Elasticsearch client
+	 * @param index Index name
+	 */
+	@Deprecated
+	public static void updateMapping(Client client, String index) {
+		String mapping = IndexSettingsReader.readUpdateMapping(index);
+		updateMappingInElasticsearch(client, index, mapping);
 	}
 
 	/**
@@ -322,6 +368,31 @@ public class IndexElasticsearchUpdater {
 	}
 
 	/**
+	 * Update mapping in Elasticsearch
+	 * @param client Elasticsearch client
+	 * @param index Index name
+	 * @param mapping Mapping if any, null if no update mapping
+	 * @throws Exception if the elasticsearch API call is failing
+	 */
+	private static void updateMappingInElasticsearch(RestClient client, String index, String mapping) throws Exception {
+		logger.trace("updateMapping([{}])", index);
+
+		assert client != null;
+		assert index != null;
+
+
+		if (mapping != null) {
+			logger.trace("Found update mapping for index [{}]: [{}]", index, mapping);
+			logger.debug("updating mapping for index [{}]", index);
+            Request request = new Request("PUT", "/" + index + "/_mapping");
+            request.setJsonEntity(mapping);
+			client.performRequest(request);
+		}
+
+		logger.trace("/updateMapping([{}])", index);
+	}
+
+	/**
 	 * Check if an index already exists
 	 * @param client Elasticsearch client
 	 * @param index Index name
@@ -354,5 +425,28 @@ public class IndexElasticsearchUpdater {
 	public static void updateSettings(RestClient client, String index) throws Exception {
 		String settings = IndexSettingsReader.readUpdateSettings(index);
 		updateIndexWithSettingsInElasticsearch(client, index, settings);
+	}
+
+	/**
+	 * Update index mapping in Elasticsearch. Read also _update_mapping.json if exists.
+	 * @param client Elasticsearch client
+	 * @param root dir within the classpath
+	 * @param index Index name
+	 * @throws Exception if the elasticsearch API call is failing
+	 */
+	public static void updateMapping(RestClient client, String root, String index) throws Exception {
+		String mapping = IndexSettingsReader.readUpdateMapping(root, index);
+		updateMappingInElasticsearch(client, index, mapping);
+	}
+
+	/**
+	 * Update index mapping in Elasticsearch. Read also _update_mapping.json if exists in default classpath dir.
+	 * @param client Elasticsearch client
+	 * @param index Index name
+	 * @throws Exception if the elasticsearch API call is failing
+	 */
+	public static void updateMapping(RestClient client, String index) throws Exception {
+		String mapping = IndexSettingsReader.readUpdateMapping(index);
+		updateMappingInElasticsearch(client, index, mapping);
 	}
 }

--- a/src/main/java/fr/pilato/elasticsearch/tools/index/IndexSettingsReader.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/index/IndexSettingsReader.java
@@ -41,7 +41,7 @@ public class IndexSettingsReader extends SettingsReader {
 	 * @param jsonFile json file to read
 	 * @return Settings
 	 */
-	public static String readSettings(String root, String index, String jsonFile) {
+	public static String readFile(String root, String index, String jsonFile) {
 		logger.trace("Reading [{}] for [{}] in [{}]...", jsonFile, index, root);
 		String settingsFile = root + "/" + index + "/" + jsonFile;
 		return readFileFromClasspath(settingsFile);
@@ -58,7 +58,7 @@ public class IndexSettingsReader extends SettingsReader {
 		if (root == null) {
 			return readSettings(index);
 		}
-		return readSettings(root, index, Defaults.IndexSettingsFileName);
+		return readFile(root, index, Defaults.IndexSettingsFileName);
 	}
 
 	/**
@@ -78,7 +78,7 @@ public class IndexSettingsReader extends SettingsReader {
      * @return Update Settings
 	 */
 	public static String readUpdateSettings(String root, String index) {
-		return readSettings(root, index, Defaults.UpdateIndexSettingsFileName);
+		return readFile(root, index, Defaults.UpdateIndexSettingsFileName);
 	}
 
 	/**
@@ -88,5 +88,24 @@ public class IndexSettingsReader extends SettingsReader {
      */
 	public static String readUpdateSettings(String index) {
 		return readUpdateSettings(Defaults.ConfigDir, index);
+	}
+
+	/**
+	 * Read index mapping
+	 * @param root dir within the classpath
+	 * @param index index name
+     * @return Update Mapping
+	 */
+	public static String readUpdateMapping(String root, String index) {
+		return readFile(root, index, Defaults.UpdateIndexMappingFileName);
+	}
+
+	/**
+	 * Read index mapping in default classpath dir
+	 * @param index index name
+     * @return Update Mapping
+     */
+	public static String readUpdateMapping(String index) {
+		return readUpdateMapping(Defaults.ConfigDir, index);
 	}
 }

--- a/src/test/java/fr/pilato/elasticsearch/tools/AbstractBeyonderTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/tools/AbstractBeyonderTest.java
@@ -19,7 +19,6 @@
 
 package fr.pilato.elasticsearch.tools;
 
-import fr.pilato.elasticsearch.tools.index.IndexSettingsReader;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
@@ -33,14 +32,14 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.singletonList;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assume.assumeThat;
 
 public abstract class AbstractBeyonderTest {
@@ -119,24 +118,6 @@ public abstract class AbstractBeyonderTest {
     }
 
     @Test
-    public void testVariableReplacement() throws Exception {
-
-      // given: A settings json with a variable that should be replaced.
-      //        And an environment variable with matching name (set in configuration of maven-surefire-plugin).
-      String folder = "models/variablereplacement";
-      String indexName = "twitter";
-
-      // when: this settings file is read
-      String settings = IndexSettingsReader.readSettings(folder, indexName);
-      Map<String, Object> settingsMap = JsonUtil.asMap(new ByteArrayInputStream(settings.getBytes()));
-
-      // then: the variables got replaced by environment variables of the same name
-      String numberOfReplicas = (String) ((Map) settingsMap.get("settings")).get("number_of_replicas");
-      assumeThat(numberOfReplicas, equalTo("2"));
-
-    }
-
-    @Test
     public void testSettingsAnalyzer() throws Exception {
         // Custom settings (analyzer)
         testBeyonder("models/settingsanalyzer",
@@ -161,21 +142,9 @@ public abstract class AbstractBeyonderTest {
     }
 
     @Test
-    public void testUpdateSettings() throws Exception {
-        // 1 _update_settings
-        testBeyonder("models/update-settings/step1",
-                singletonList("twitter"),
-                null);
-        testBeyonder("models/update-settings/step2",
-                singletonList("twitter"),
-                null);
-    }
-
-    @Test
     public void testWrongClasspathDir() throws Exception {
         testBeyonder("models/bad-classpath-7/doesnotexist",
                 null,
                 null);
     }
-
 }

--- a/src/test/java/fr/pilato/elasticsearch/tools/AbstractBeyonderTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/tools/AbstractBeyonderTest.java
@@ -46,8 +46,8 @@ public abstract class AbstractBeyonderTest {
 
     static final Logger logger = LoggerFactory.getLogger(AbstractBeyonderTest.class);
 
-    private final static String DEFAULT_TEST_CLUSTER = "http://127.0.0.1:9400";
-    private final static Integer DEFAULT_TEST_CLUSTER_TRANSPORT_PORT = 9500;
+    private final static String DEFAULT_TEST_CLUSTER = "http://127.0.0.1:9200";
+    private final static Integer DEFAULT_TEST_CLUSTER_TRANSPORT_PORT = 9300;
 
     final static String testCluster = System.getProperty("tests.cluster", DEFAULT_TEST_CLUSTER);
     final static String testClusterUser = System.getProperty("tests.cluster.user");

--- a/src/test/java/fr/pilato/elasticsearch/tools/JsonUtil.java
+++ b/src/test/java/fr/pilato/elasticsearch/tools/JsonUtil.java
@@ -44,7 +44,7 @@ public class JsonUtil {
 
     public static Map<String, Object> asMap(InputStream stream) {
         try {
-            return mapper.readValue(stream, new TypeReference<Map<String, Object>>(){});
+            return mapper.readValue(stream, new TypeReference<>() {});
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/test/resources/models/update-mapping/step1/twitter/_settings.json
+++ b/src/test/resources/models/update-mapping/step1/twitter/_settings.json
@@ -1,0 +1,8 @@
+{
+  "mappings" : {
+    "properties" : {
+      "message" : {"type" : "text", "store" : true, "analyzer" : "simple" },
+      "foo" : { "type" : "text" }
+    }
+  }
+}

--- a/src/test/resources/models/update-mapping/step2/twitter/_update_mapping.json
+++ b/src/test/resources/models/update-mapping/step2/twitter/_update_mapping.json
@@ -1,0 +1,6 @@
+{
+    "properties": {
+        "message" : {"type" : "text", "store" : true, "analyzer" : "simple", "search_analyzer": "keyword" },
+        "bar" : { "type" : "text" }
+    }
+}

--- a/src/test/resources/transport/models/update-mapping/step1/twitter/_settings.json
+++ b/src/test/resources/transport/models/update-mapping/step1/twitter/_settings.json
@@ -1,0 +1,10 @@
+{
+  "mappings" : {
+    "_doc": {
+      "properties" : {
+        "message" : {"type" : "text", "store" : true, "analyzer" : "simple" },
+        "foo" : { "type" : "text" }
+      }
+    }
+  }
+}

--- a/src/test/resources/transport/models/update-mapping/step2/twitter/_update_mapping.json
+++ b/src/test/resources/transport/models/update-mapping/step2/twitter/_update_mapping.json
@@ -1,0 +1,6 @@
+{
+    "properties": {
+        "message" : {"type" : "text", "store" : true, "analyzer" : "simple", "search_analyzer": "keyword" },
+        "bar" : { "type" : "text" }
+    }
+}


### PR DESCRIPTION
For example, let say you already have an index with the following settings and mapping:

```json
{
  "settings": {
    "number_of_shards": 3,
    "number_of_replicas": 0
  },
  "mappings": {
    "properties": {
      "message": { "type": "text" },
      "foo": { "type": "text" }
    }
  }
}
```

You can provide a file named `_update_settings.json` to update your index settings
and a file named `_update_mapping.json` if you want to update an existing mapping.
Note that Elasticsearch do not allow updating all settings and mappings.

You can for example add a new field, or change the `search_analyzer` for a given field but you can not modify
the field `type`.

Considering the previous example we saw, you can create a `elasticsearch/twitter/_update_settings.json` to update the
number of replicas:

```json
{
    "number_of_replicas" : 1
}
```

And you can create `elasticsearch/twitter/_update_mapping.json`:

```json
{
  "properties": {
    "message" : {"type" : "text", "search_analyzer": "keyword" },
    "bar" : { "type" : "text" }
  }
}
```

This will change the `search_analyzer` for the `message` field and will add a new field named `bar`.
All other existing fields (like `foo` in the previous example) won't be changed.

Closes #92.