### PR TITLE
No need to delete templates before updating them

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Release notes
 
 * `_pipeline` dir has been deprecated by `_pipelines` dir.
 * `force` parameter is not applied anymore to pipelines. So pipelines are always updated.
+* `force` parameter is not applied anymore to templates, component templates and index templates. So they are always updated.
 
 Getting Started
 ===============

--- a/src/main/java/fr/pilato/elasticsearch/tools/ElasticsearchBeyonder.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/ElasticsearchBeyonder.java
@@ -111,7 +111,7 @@ public class ElasticsearchBeyonder {
 		for (String templateName : templateNames) {
 			logger.warn("Legacy Templates are deprecated in Elasticsearch. Switch to Index Templates instead by using {}/{}{}",
 					Defaults.IndexTemplatesDir, templateName, Defaults.JsonFileExtension);
-			createTemplate(client, root, templateName, force);
+			createTemplate(client, root, templateName);
 		}
 
 		// create component templates
@@ -180,7 +180,7 @@ public class ElasticsearchBeyonder {
 		// create templates
 		List<String> templateNames = ResourceList.getResourceNames(root, Defaults.TemplateDir);
 		for (String templateName : templateNames) {
-			createTemplate(client, root, templateName, force);
+			createTemplate(client, root, templateName);
 		}
 
 		// create indices

--- a/src/main/java/fr/pilato/elasticsearch/tools/ElasticsearchBeyonder.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/ElasticsearchBeyonder.java
@@ -117,13 +117,13 @@ public class ElasticsearchBeyonder {
 		// create component templates
 		List<String> componentTemplates = ResourceList.getResourceNames(root, Defaults.ComponentTemplatesDir);
 		for (String componentTemplateName : componentTemplates) {
-			createComponentTemplate(client, root, componentTemplateName, force);
+			createComponentTemplate(client, root, componentTemplateName);
 		}
 
 		// create index templates
 		List<String> indexTemplateNames = ResourceList.getResourceNames(root, Defaults.IndexTemplatesDir);
 		for (String indexTemplateName : indexTemplateNames) {
-			createIndexTemplate(client, root, indexTemplateName, force);
+			createIndexTemplate(client, root, indexTemplateName);
 		}
 
 		// create pipelines

--- a/src/main/java/fr/pilato/elasticsearch/tools/updaters/ElasticsearchComponentTemplateUpdater.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/updaters/ElasticsearchComponentTemplateUpdater.java
@@ -43,36 +43,11 @@ public class ElasticsearchComponentTemplateUpdater {
 	 * @param client Elasticsearch client
 	 * @param root dir within the classpath
 	 * @param template Template name
-	 * @param force set it to true if you want to force cleaning template before adding it
 	 * @throws Exception if something goes wrong
 	 */
-	public static void createComponentTemplate(RestClient client, String root, String template, boolean force) throws Exception {
+	public static void createComponentTemplate(RestClient client, String root, String template) throws Exception {
 		String json = getJsonContent(root, SettingsFinder.Defaults.ComponentTemplatesDir, template);
-		createComponentTemplateWithJson(client, template, json, force);
-	}
-
-	/**
-	 * Create a new component template in Elasticsearch
-	 * @param client Elasticsearch client
-	 * @param template Template name
-	 * @param json JSon content for the template
-	 * @param force set it to true if you want to force cleaning template before adding it
-	 * @throws Exception if something goes wrong
-	 */
-	public static void createComponentTemplateWithJson(RestClient client, String template, String json, boolean force) throws Exception {
-		if (isComponentTemplateExist(client, template)) {
-			if (force) {
-				logger.debug("Component Template [{}] already exists. Force is set. Removing it.", template);
-				removeComponentTemplate(client, template);
-			} else {
-				logger.debug("Component Template [{}] already exists.", template);
-			}
-		}
-
-		if (!isComponentTemplateExist(client, template)) {
-			logger.debug("Component Template [{}] doesn't exist. Creating it.", template);
-			createComponentTemplateWithJsonInElasticsearch(client, template, json);
-		}
+		createComponentTemplateWithJsonInElasticsearch(client, template, json);
 	}
 
 	/**
@@ -98,29 +73,5 @@ public class ElasticsearchComponentTemplateUpdater {
 		}
 
 		logger.trace("/createComponentTemplate([{}])", template);
-	}
-
-	/**
-	 * Check if an component template exists
-	 * @param client Elasticsearch client
-	 * @param template template name
-	 * @return true if the template exists
-	 * @throws IOException if something goes wrong
-	 */
-	public static boolean isComponentTemplateExist(RestClient client, String template) throws IOException {
-		Response response = client.performRequest(new Request("HEAD", "/_component_template/" + template));
-		return response.getStatusLine().getStatusCode() == 200;
-	}
-
-	/**
-	 * Remove an component template
-	 * @param client Elasticsearch client
-	 * @param template template name
-	 * @throws Exception if something goes wrong
-	 */
-	public static void removeComponentTemplate(RestClient client, String template) throws Exception {
-		logger.trace("removeComponentTemplate({})", template);
-		client.performRequest(new Request("DELETE", "/_component_template/" + template));
-		logger.trace("/removeComponentTemplate({})", template);
 	}
 }

--- a/src/main/java/fr/pilato/elasticsearch/tools/updaters/ElasticsearchIndexTemplateUpdater.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/updaters/ElasticsearchIndexTemplateUpdater.java
@@ -26,8 +26,6 @@ import org.elasticsearch.client.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-
 import static fr.pilato.elasticsearch.tools.util.SettingsReader.getJsonContent;
 
 /**
@@ -43,36 +41,11 @@ public class ElasticsearchIndexTemplateUpdater {
 	 * @param client Elasticsearch client
 	 * @param root dir within the classpath
 	 * @param template Template name
-	 * @param force set it to true if you want to force cleaning template before adding it
 	 * @throws Exception if something goes wrong
 	 */
-	public static void createIndexTemplate(RestClient client, String root, String template, boolean force) throws Exception {
+	public static void createIndexTemplate(RestClient client, String root, String template) throws Exception {
 		String json = getJsonContent(root, SettingsFinder.Defaults.IndexTemplatesDir, template);
-		createIndexTemplateWithJson(client, template, json, force);
-	}
-
-	/**
-	 * Create a new index template in Elasticsearch
-	 * @param client Elasticsearch client
-	 * @param template Template name
-	 * @param json JSon content for the template
-	 * @param force set it to true if you want to force cleaning template before adding it
-	 * @throws Exception if something goes wrong
-	 */
-	public static void createIndexTemplateWithJson(RestClient client, String template, String json, boolean force) throws Exception {
-		if (isIndexTemplateExist(client, template)) {
-			if (force) {
-				logger.debug("Index Template [{}] already exists. Force is set. Removing it.", template);
-				removeIndexTemplate(client, template);
-			} else {
-				logger.debug("Index Template [{}] already exists.", template);
-			}
-		}
-
-		if (!isIndexTemplateExist(client, template)) {
-			logger.debug("Index Template [{}] doesn't exist. Creating it.", template);
-			createIndexTemplateWithJsonInElasticsearch(client, template, json);
-		}
+		createIndexTemplateWithJsonInElasticsearch(client, template, json);
 	}
 
 	/**
@@ -98,29 +71,5 @@ public class ElasticsearchIndexTemplateUpdater {
 		}
 
 		logger.trace("/createIndexTemplate([{}])", template);
-	}
-
-	/**
-	 * Check if an index template exists
-	 * @param client Elasticsearch client
-	 * @param template template name
-	 * @return true if the template exists
-	 * @throws IOException if something goes wrong
-	 */
-	public static boolean isIndexTemplateExist(RestClient client, String template) throws IOException {
-		Response response = client.performRequest(new Request("HEAD", "/_index_template/" + template));
-		return response.getStatusLine().getStatusCode() == 200;
-	}
-
-	/**
-	 * Remove an index template
-	 * @param client Elasticsearch client
-	 * @param template template name
-	 * @throws Exception if something goes wrong
-	 */
-	public static void removeIndexTemplate(RestClient client, String template) throws Exception {
-		logger.trace("removeIndexTemplate({})", template);
-		client.performRequest(new Request("DELETE", "/_index_template/" + template));
-		logger.trace("/removeIndexTemplate({})", template);
 	}
 }

--- a/src/main/java/fr/pilato/elasticsearch/tools/updaters/ElasticsearchTemplateUpdater.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/updaters/ElasticsearchTemplateUpdater.java
@@ -47,40 +47,13 @@ public class ElasticsearchTemplateUpdater {
 	 * @param client Elasticsearch client
 	 * @param root dir within the classpath
 	 * @param template Template name
-     * @param force set it to true if you want to force cleaning template before adding it
 	 * @throws Exception if something goes wrong
 	 * @deprecated Will be removed when we don't support TransportClient anymore
 	 */
 	@Deprecated
-	public static void createTemplate(Client client, String root, String template, boolean force) throws Exception {
+	public static void createTemplate(Client client, String root, String template) throws Exception {
 		String json = getJsonContent(root, SettingsFinder.Defaults.TemplateDir, template);
-		createTemplateWithJson(client, template, json, force);
-	}
-
-	/**
-	 * Create a new template in Elasticsearch
-	 * @param client Elasticsearch client
-	 * @param template Template name
-	 * @param json JSon content for the template
-	 * @param force set it to true if you want to force cleaning template before adding it
-     * @throws Exception if something goes wrong
-     * @deprecated Will be removed when we don't support TransportClient anymore
-	 */
-	@Deprecated
-	public static void createTemplateWithJson(Client client, String template, String json, boolean force) throws Exception {
-		if (isTemplateExist(client, template)) {
-			if (force) {
-				logger.debug("Template [{}] already exists. Force is set. Removing it.", template);
-				removeTemplate(client, template);
-			} else {
-				logger.debug("Template [{}] already exists.", template);
-			}
-		}
-
-		if (!isTemplateExist(client, template)) {
-			logger.debug("Template [{}] doesn't exist. Creating it.", template);
-			createTemplateWithJsonInElasticsearch(client, template, json);
-		}
+		createTemplateWithJsonInElasticsearch(client, template, json);
 	}
 
 	/**
@@ -112,42 +85,16 @@ public class ElasticsearchTemplateUpdater {
 	}
 
 	/**
-	 * Check if a template exists
-     * @param client Elasticsearch client
-	 * @param template template name
-     * @return true if the template exists
-     * @deprecated Will be removed when we don't support TransportClient anymore
-	 */
-	@Deprecated
-	public static boolean isTemplateExist(Client client, String template) {
-		return !client.admin().indices().prepareGetTemplates(template).get().getIndexTemplates().isEmpty();
-	}
-
-	/**
-	 * Remove a template
-     * @param client Elasticsearch client
-	 * @param template template name
-     * @deprecated Will be removed when we don't support TransportClient anymore
-	 */
-	@Deprecated
-	public static void removeTemplate(Client client, String template) {
-		logger.trace("removeTemplate({})", template);
-		client.admin().indices().prepareDeleteTemplate(template).get();
-		logger.trace("/removeTemplate({})", template);
-	}
-
-	/**
 	 * Create a legacy template in Elasticsearch.
 	 * @param client Elasticsearch client
 	 * @param root dir within the classpath
 	 * @param template Template name
-     * @param force set it to true if you want to force cleaning template before adding it
      * @throws Exception if something goes wrong
 	 */
 	@Deprecated
-	public static void createTemplate(RestClient client, String root, String template, boolean force) throws Exception {
+	public static void createTemplate(RestClient client, String root, String template) throws Exception {
 		String json = getJsonContent(root, SettingsFinder.Defaults.TemplateDir, template);
-		createTemplateWithJson(client, template, json, force);
+		createTemplateWithJsonInElasticsearch(client, template, json);
 	}
 
 	/**
@@ -160,19 +107,7 @@ public class ElasticsearchTemplateUpdater {
 	 */
 	@Deprecated
 	public static void createTemplateWithJson(RestClient client, String template, String json, boolean force) throws Exception {
-		if (isTemplateExist(client, template)) {
-			if (force) {
-				logger.debug("Template [{}] already exists. Force is set. Removing it.", template);
-				removeTemplate(client, template);
-			} else {
-				logger.debug("Template [{}] already exists.", template);
-			}
-		}
-
-		if (!isTemplateExist(client, template)) {
-			logger.debug("Template [{}] doesn't exist. Creating it.", template);
-			createTemplateWithJsonInElasticsearch(client, template, json);
-		}
+		createTemplateWithJsonInElasticsearch(client, template, json);
 	}
 
 	/**

--- a/src/test/java/fr/pilato/elasticsearch/tools/BeyonderRestIT.java
+++ b/src/test/java/fr/pilato/elasticsearch/tools/BeyonderRestIT.java
@@ -47,7 +47,6 @@ import static fr.pilato.elasticsearch.tools.updaters.ElasticsearchComponentTempl
 import static fr.pilato.elasticsearch.tools.updaters.ElasticsearchIndexTemplateUpdater.isIndexTemplateExist;
 import static fr.pilato.elasticsearch.tools.updaters.ElasticsearchIndexUpdater.isIndexExist;
 import static fr.pilato.elasticsearch.tools.updaters.ElasticsearchPipelineUpdater.isPipelineExist;
-import static fr.pilato.elasticsearch.tools.updaters.ElasticsearchTemplateUpdater.isTemplateExist;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -123,7 +122,7 @@ public class BeyonderRestIT extends AbstractBeyonderTest {
             boolean allExists = true;
 
             for (String template : templates) {
-                if (!isTemplateExist(client, template)) {
+                if (client.performRequest(new Request("HEAD", "/_template/" + template)).getStatusLine().getStatusCode() != 200) {
                     allExists = false;
                 }
             }

--- a/src/test/java/fr/pilato/elasticsearch/tools/BeyonderRestIT.java
+++ b/src/test/java/fr/pilato/elasticsearch/tools/BeyonderRestIT.java
@@ -21,7 +21,6 @@ package fr.pilato.elasticsearch.tools;
 
 import fr.pilato.elasticsearch.tools.updaters.ElasticsearchAliasUpdater;
 import fr.pilato.elasticsearch.tools.updaters.ElasticsearchIndexUpdater;
-import fr.pilato.elasticsearch.tools.updaters.ElasticsearchPipelineUpdater;
 import fr.pilato.elasticsearch.tools.util.SettingsFinder;
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.io.IOUtils;
@@ -43,8 +42,6 @@ import java.util.List;
 import java.util.Map;
 
 import static fr.pilato.elasticsearch.tools.JsonUtil.asMap;
-import static fr.pilato.elasticsearch.tools.updaters.ElasticsearchComponentTemplateUpdater.isComponentTemplateExist;
-import static fr.pilato.elasticsearch.tools.updaters.ElasticsearchIndexTemplateUpdater.isIndexTemplateExist;
 import static fr.pilato.elasticsearch.tools.updaters.ElasticsearchIndexUpdater.isIndexExist;
 import static fr.pilato.elasticsearch.tools.updaters.ElasticsearchPipelineUpdater.isPipelineExist;
 import static java.util.Arrays.asList;
@@ -122,7 +119,7 @@ public class BeyonderRestIT extends AbstractBeyonderTest {
             boolean allExists = true;
 
             for (String template : templates) {
-                if (client.performRequest(new Request("HEAD", "/_template/" + template)).getStatusLine().getStatusCode() != 200) {
+                if (!existObjectInElasticsearch("/_template/" + template)) {
                     allExists = false;
                 }
             }
@@ -134,7 +131,7 @@ public class BeyonderRestIT extends AbstractBeyonderTest {
             boolean allExists = true;
 
             for (String template : componentTemplates) {
-                if (!isComponentTemplateExist(client, template)) {
+                if (!existObjectInElasticsearch("/_component_template/" + template)) {
                     allExists = false;
                 }
             }
@@ -146,7 +143,7 @@ public class BeyonderRestIT extends AbstractBeyonderTest {
             boolean allExists = true;
 
             for (String template : indexTemplates) {
-                if (!isIndexTemplateExist(client, template)) {
+                if (!existObjectInElasticsearch("/_index_template/" + template)) {
                     allExists = false;
                 }
             }
@@ -176,6 +173,10 @@ public class BeyonderRestIT extends AbstractBeyonderTest {
             }
             assertThat(allExists, is(true));
         }
+    }
+
+    private boolean existObjectInElasticsearch(String url) throws IOException {
+        return client.performRequest(new Request("HEAD", url)).getStatusLine().getStatusCode() == 200;
     }
 
     // This is a manual test as we don't have a real support of this in Beyonder yet

--- a/src/test/java/fr/pilato/elasticsearch/tools/BeyonderTransportIT.java
+++ b/src/test/java/fr/pilato/elasticsearch/tools/BeyonderTransportIT.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.Map;
 
 import static fr.pilato.elasticsearch.tools.updaters.ElasticsearchIndexUpdater.isIndexExist;
-import static fr.pilato.elasticsearch.tools.updaters.ElasticsearchTemplateUpdater.isTemplateExist;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -175,7 +174,7 @@ public class BeyonderTransportIT extends AbstractBeyonderTest {
             boolean allExists = true;
 
             for (String template : templates) {
-                if (!isTemplateExist(client, template)) {
+                if (client.admin().indices().prepareGetTemplates(template).get().getIndexTemplates().isEmpty()) {
                     allExists = false;
                 }
             }


### PR DESCRIPTION
If templates are already existing, you can just send the update template again to overwrite the template.
No need to remove them then update.

That creates a short period of time where a template can be removed and a create index request happen in the same time.
That will produce unexpected results.

As a consequence, the `force` parameter is not applied anymore to templates, component templates and index templates. So they are always updated.

Closes #167.