### PR TITLE
Remove the `merge` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Release notes
 * `_pipeline` dir has been deprecated by `_pipelines` dir.
 * `force` parameter is not applied anymore to pipelines. So pipelines are always updated.
 * `force` parameter is not applied anymore to templates, component templates and index templates. So they are always updated.
+* method `start(RestClient client, String root, boolean merge, boolean force)` is now deprecated as the `merge` parameter
+  is not used anymore. Use instead the `start(RestClient client, String root, boolean force)` method.
 
 Getting Started
 ===============

--- a/src/main/java/fr/pilato/elasticsearch/tools/ElasticsearchBeyonder.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/ElasticsearchBeyonder.java
@@ -98,12 +98,25 @@ public class ElasticsearchBeyonder {
 	 * Automatically scan classpath and create indices, mappings, templates, and other settings.
 	 * @param client elasticsearch client
 	 * @param root dir within the classpath
-	 * @param merge whether or not to merge mappings
+	 * @param merge whether or not to merge mappings (not used anymore)
 	 * @param force whether or not to force creation of indices and templates
 	 * @throws Exception when beyonder can not start
 	 * @since 6.1
 	 */
+	@Deprecated
 	public static void start(RestClient client, String root, boolean merge, boolean force) throws Exception {
+		start(client, root, force);
+	}
+
+	/**
+	 * Automatically scan classpath and create indices, mappings, templates, and other settings.
+	 * @param client elasticsearch client
+	 * @param root dir within the classpath
+	 * @param force whether or not to force creation of indices and templates
+	 * @throws Exception when beyonder can not start
+	 * @since 6.1
+	 */
+	public static void start(RestClient client, String root, boolean force) throws Exception {
 		logger.info("starting automatic settings/mappings discovery");
 
 		// create legacy templates


### PR DESCRIPTION
The method `start(RestClient client, String root, boolean merge, boolean force)` is now deprecated as the `merge` parameter
  is not used anymore. Use instead the `start(RestClient client, String root, boolean force)` method.