### PR TITLE
Add support for aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Release notes
 * `force` parameter is not applied anymore to templates, component templates and index templates. So they are always updated.
 * method `start(RestClient client, String root, boolean merge, boolean force)` is now deprecated as the `merge` parameter
   is not used anymore. Use instead the `start(RestClient client, String root, boolean force)` method.
+* support for the aliases API has been added.
 
 Getting Started
 ===============
@@ -225,6 +226,23 @@ And you can create `elasticsearch/twitter/_update_mapping.json`:
 
 This will change the `search_analyzer` for the `message` field and will add a new field named `bar`.
 All other existing fields (like `foo` in the previous example) won't be changed.
+
+Managing aliases
+----------------
+
+An alias is helpful to define or remove an alias to a given index. You could also use index templates to do that 
+automatically when the index is created, but you can also define a file `elasticsearch/_aliases.json`:
+
+```json
+{
+  "actions" : [
+    { "remove": { "index": "test_1", "alias": "test" } },
+    { "add":  { "index": "test_2", "alias": "test" } }
+  ]
+}
+```
+
+When Beyonder starts, it will automatically send the content to the [Aliases API](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html).
 
 Managing index templates (aka templates V2)
 -------------------------------------------

--- a/src/main/java/fr/pilato/elasticsearch/tools/ElasticsearchBeyonder.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/ElasticsearchBeyonder.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.List;
 
+import static fr.pilato.elasticsearch.tools.updaters.ElasticsearchAliasUpdater.manageAliases;
 import static fr.pilato.elasticsearch.tools.updaters.ElasticsearchComponentTemplateUpdater.createComponentTemplate;
 import static fr.pilato.elasticsearch.tools.updaters.ElasticsearchIndexUpdater.createIndex;
 import static fr.pilato.elasticsearch.tools.updaters.ElasticsearchIndexUpdater.updateMapping;
@@ -165,6 +166,10 @@ public class ElasticsearchBeyonder {
 			updateSettings(client, root, indexName);
 			updateMapping(client, root, indexName);
 		}
+
+		// Manage aliases
+		manageAliases(client, root);
+
 		logger.info("start done. Rock & roll!");
 	}
 

--- a/src/main/java/fr/pilato/elasticsearch/tools/util/ResourceList.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/util/ResourceList.java
@@ -186,6 +186,7 @@ public class ResourceList {
                         !key.equals(SettingsFinder.Defaults.TemplatesDir) &&
                         !key.equals(SettingsFinder.Defaults.PipelineDir) &&
                         !key.equals(SettingsFinder.Defaults.PipelinesDir) &&
+                        !key.equals(SettingsFinder.Defaults.AliasesFile + SettingsFinder.Defaults.JsonFileExtension) &&
                         !keys.contains(key)) {
                     logger.trace(" - found [{}].", key);
                     keys.add(key);

--- a/src/main/java/fr/pilato/elasticsearch/tools/util/SettingsFinder.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/util/SettingsFinder.java
@@ -39,6 +39,7 @@ public class SettingsFinder {
 		public static String PipelinesDir = "_pipelines";
 		@Deprecated
 		public static String PipelineDir = "_pipeline";
+		public static String AliasesFile = "_aliases";
 
 		/**
 		 * Default setting of whether or not to merge mappings on start.

--- a/src/main/java/fr/pilato/elasticsearch/tools/util/SettingsReader.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/util/SettingsReader.java
@@ -58,7 +58,10 @@ public class SettingsReader {
 		if (root == null) {
 			path = SettingsFinder.Defaults.ConfigDir;
 		}
-		path += "/" + subdir + "/" + name + SettingsFinder.Defaults.JsonFileExtension;
+		if (subdir != null) {
+			path += "/" + subdir;
+		}
+		path += "/" + name + SettingsFinder.Defaults.JsonFileExtension;
 		logger.debug("Reading file [{}] from the classpath.", path);
 		return readFileFromClasspath(path);
 	}

--- a/src/test/java/fr/pilato/elasticsearch/tools/BeyonderRestIT.java
+++ b/src/test/java/fr/pilato/elasticsearch/tools/BeyonderRestIT.java
@@ -73,11 +73,13 @@ public class BeyonderRestIT extends AbstractBeyonderTest {
     }
 
     @Before @After
-    public void cleanCluster() throws Exception {
+    public void cleanCluster() {
         // DELETE /twitter
         launchAndIgnoreFailure(() -> client.performRequest(new Request("DELETE", "/twitter")));
-        // DELETE /test_aliases
-        launchAndIgnoreFailure(() -> client.performRequest(new Request("DELETE", "/test_aliases")));
+        // DELETE /test_1
+        launchAndIgnoreFailure(() -> client.performRequest(new Request("DELETE", "/test_1")));
+        // DELETE /test_2
+        launchAndIgnoreFailure(() -> client.performRequest(new Request("DELETE", "/test_2")));
 
         // DELETE /_ingest/pipeline/twitter_pipeline
         launchAndIgnoreFailure(() -> client.performRequest(new Request("DELETE", "/_ingest/pipeline/twitter_pipeline")));
@@ -179,14 +181,12 @@ public class BeyonderRestIT extends AbstractBeyonderTest {
         return client.performRequest(new Request("HEAD", url)).getStatusLine().getStatusCode() == 200;
     }
 
-    // This is a manual test as we don't have a real support of this in Beyonder yet
-    // See https://github.com/dadoonet/elasticsearch-beyonder/issues/2
     @Test
     public void testAliases() throws Exception {
-        ElasticsearchIndexUpdater.createIndex(client, SettingsFinder.Defaults.ConfigDir, "test_aliases", true);
-        ElasticsearchAliasUpdater.createAlias(client, "foo", "test_aliases");
-        Map<String, Object> response = asMap(client.performRequest(new Request("GET", "/_alias/foo")));
-        assertThat(response, hasKey("test_aliases"));
+        ElasticsearchBeyonder.start(client, "models/aliases");
+        Map<String, Object> response = asMap(client.performRequest(new Request("GET", "/_alias/test")));
+        assertThat(response, not(hasKey("test_1")));
+        assertThat(response, hasKey("test_2"));
     }
 
     @Test

--- a/src/test/resources/models/aliases/_aliases.json
+++ b/src/test/resources/models/aliases/_aliases.json
@@ -1,0 +1,6 @@
+{
+  "actions" : [
+    { "remove": { "index": "test_1", "alias": "test" } },
+    { "add":  { "index": "test_2", "alias": "test" } }
+  ]
+}

--- a/src/test/resources/models/aliases/test_1/_settings.json
+++ b/src/test/resources/models/aliases/test_1/_settings.json
@@ -1,0 +1,10 @@
+{
+  "mappings": {
+    "properties" : {
+      "message" : {"type" : "text", "store" : true}
+    }
+  },
+  "aliases": {
+    "test": { }
+  }
+}

--- a/src/test/resources/models/aliases/test_2/_settings.json
+++ b/src/test/resources/models/aliases/test_2/_settings.json
@@ -1,0 +1,7 @@
+{
+  "mappings": {
+    "properties" : {
+      "message" : {"type" : "text", "store" : true}
+    }
+  }
+}


### PR DESCRIPTION
An alias is helpful to define or remove an alias to a given index. You could also use index templates to do that
automatically when the index is created, but you can also define a file `elasticsearch/_aliases.json`:

```json
{
  "actions" : [
    { "remove": { "index": "test_1", "alias": "test" } },
    { "add":  { "index": "test_2", "alias": "test" } }
  ]
}
```

When Beyonder starts, it will automatically send the content to the [Aliases API](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html).

Closes #2.