### PR TITLE
Do not load data if the index already exists when starting

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,9 +504,7 @@ And the `test_2/_data/abcd.ndjson` file contains:
 { "message" : "message 5" }
 ```
 
-When Beyonder starts,
-
-Beyonder will:
+When Beyonder starts, it will:
 
 * Create the `person` index with the mapping defined in `elasticsearch/person/_index_templates/person.json`.
 * Create the `test_1` index with the settings defined in `elasticsearch/test_1/_settings.json`.
@@ -521,6 +519,9 @@ specified within the bulk files.
 
 Note that files are sorted by name before being loaded which means that a file `bulk_001.ndjson` will be loaded before
 `bulk_002.ndjson`.
+
+If the index already existed before Beyonder starts, the data won't be loaded unless you are using the `force` option.
+This does not apply to the `_data` root directory which will **always load the data at every startup**.
 
 # Tests
 

--- a/src/main/documentation/README.md
+++ b/src/main/documentation/README.md
@@ -504,9 +504,7 @@ And the `test_2/_data/abcd.ndjson` file contains:
 { "message" : "message 5" }
 ```
 
-When Beyonder starts,
-
-Beyonder will:
+When Beyonder starts, it will:
 
 * Create the `person` index with the mapping defined in `elasticsearch/person/_index_templates/person.json`.
 * Create the `test_1` index with the settings defined in `elasticsearch/test_1/_settings.json`.
@@ -521,6 +519,9 @@ specified within the bulk files.
 
 Note that files are sorted by name before being loaded which means that a file `bulk_001.ndjson` will be loaded before
 `bulk_002.ndjson`.
+
+If the index already existed before Beyonder starts, the data won't be loaded unless you are using the `force` option.
+This does not apply to the `_data` root directory which will **always load the data at every startup**.
 
 # Tests
 

--- a/src/main/java/fr/pilato/elasticsearch/tools/ElasticsearchBeyonder.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/ElasticsearchBeyonder.java
@@ -25,6 +25,7 @@ import org.elasticsearch.client.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -132,8 +133,12 @@ public class ElasticsearchBeyonder {
 
 		// create indices
 		Collection<String> indexNames = ResourceList.findIndexNames(root);
+		// Save the list of created indices within a Collection
+		Collection<String> createdIndices = new ArrayList<>();
 		for (String indexName : indexNames) {
-			createIndex(client, root, indexName, force);
+			if (createIndex(client, root, indexName, force)) {
+				createdIndices.add(indexName);
+			}
 			updateSettings(client, root, indexName);
 			updateMapping(client, root, indexName);
 		}
@@ -142,7 +147,7 @@ public class ElasticsearchBeyonder {
 		manageAliases(client, root);
 
 		// index sample data if any
-		for (String indexName : indexNames) {
+		for (String indexName : createdIndices) {
 			Collection<String> bulkFiles = ResourceList.findBulkFiles(root, indexName);
 			loadBulkData(client, root, indexName, bulkFiles);
 			Collection<String> singleFiles = ResourceList.findJsonFiles(root, indexName);

--- a/src/main/java/fr/pilato/elasticsearch/tools/updaters/ElasticsearchIndexUpdater.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/updaters/ElasticsearchIndexUpdater.java
@@ -45,9 +45,9 @@ public class ElasticsearchIndexUpdater {
 	 * @param force Remove index if exists (Warning: remove all data)
 	 * @throws Exception if the elasticsearch API call is failing
 	 */
-	public static void createIndex(RestClient client, String root, String index, boolean force) throws Exception {
+	public static boolean createIndex(RestClient client, String root, String index, boolean force) throws Exception {
 		String json = getJsonContent(root, index, SettingsFinder.Defaults.IndexSettingsFileName);
-		createIndexWithSettings(client, index, json, force);
+		return createIndexWithSettings(client, index, json, force);
 	}
 
 	/**
@@ -56,9 +56,10 @@ public class ElasticsearchIndexUpdater {
 	 * @param index Index name
 	 * @param settings Settings if any, null if no specific settings
 	 * @param force Remove index if exists (Warning: remove all data)
+	 * @return true if we created the index and false if the index already existed
 	 * @throws Exception if the elasticsearch API call is failing
 	 */
-	public static void createIndexWithSettings(RestClient client, String index, String settings, boolean force) throws Exception {
+	public static boolean createIndexWithSettings(RestClient client, String index, String settings, boolean force) throws Exception {
 		if (force && isIndexExist(client, index)) {
 			logger.debug("Index [{}] already exists but force set to true. Removing all data!", index);
 			removeIndexInElasticsearch(client, index);
@@ -66,8 +67,10 @@ public class ElasticsearchIndexUpdater {
 		if (force || !isIndexExist(client, index)) {
 			logger.debug("Index [{}] doesn't exist. Creating it.", index);
 			createIndexWithSettingsInElasticsearch(client, index, settings);
+			return true;
 		} else {
 			logger.debug("Index [{}] already exists.", index);
+			return false;
 		}
 	}
 


### PR DESCRIPTION
If an index already exists, we probably don't want to add even more data to it as it might have been automatically loaded already from a previous run.

Relates to #346.
Closes #347.