### PR TITLE
Manage rollover and date maths indices like `<logstash-{now/d-2d}-000001>`

### DIFF
--- a/src/main/java/fr/pilato/elasticsearch/tools/updaters/ElasticsearchAliasUpdater.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/updaters/ElasticsearchAliasUpdater.java
@@ -33,7 +33,7 @@ public class ElasticsearchAliasUpdater {
     private static final Logger logger = LoggerFactory.getLogger(ElasticsearchAliasUpdater.class);
 
     /**
-     * Create a component template in Elasticsearch.
+     * Manage global aliases in Elasticsearch.
      * @param client Elasticsearch client
      * @param root dir within the classpath
      * @throws Exception if something goes wrong
@@ -52,7 +52,7 @@ public class ElasticsearchAliasUpdater {
      * @param json JSon content for the aliases
      * @throws Exception if something goes wrong
      */
-    public static void manageAliasesWithJsonInElasticsearch(RestClient client, String json) throws Exception {
+    private static void manageAliasesWithJsonInElasticsearch(RestClient client, String json) throws Exception {
         logger.trace("manageAliases()");
 
         assert client != null;

--- a/src/main/java/fr/pilato/elasticsearch/tools/updaters/ElasticsearchIndexUpdater.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/updaters/ElasticsearchIndexUpdater.java
@@ -27,6 +27,10 @@ import org.elasticsearch.client.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+import static fr.pilato.elasticsearch.tools.util.ResourceList.replaceIndexName;
 import static fr.pilato.elasticsearch.tools.util.SettingsReader.getJsonContent;
 
 /**
@@ -59,7 +63,7 @@ public class ElasticsearchIndexUpdater {
 	 * @return true if we created the index and false if the index already existed
 	 * @throws Exception if the elasticsearch API call is failing
 	 */
-	public static boolean createIndexWithSettings(RestClient client, String index, String settings, boolean force) throws Exception {
+	private static boolean createIndexWithSettings(RestClient client, String index, String settings, boolean force) throws Exception {
 		if (force && isIndexExist(client, index)) {
 			logger.debug("Index [{}] already exists but force set to true. Removing all data!", index);
 			removeIndexInElasticsearch(client, index);
@@ -80,7 +84,7 @@ public class ElasticsearchIndexUpdater {
 	 * @param index Index name
 	 * @throws Exception if the elasticsearch API call is failing
 	 */
-	public static void removeIndexInElasticsearch(RestClient client, String index) throws Exception {
+	private static void removeIndexInElasticsearch(RestClient client, String index) throws Exception {
 		logger.trace("removeIndex([{}])", index);
 
 		assert client != null;
@@ -189,9 +193,16 @@ public class ElasticsearchIndexUpdater {
 	 * @return true if index already exists
 	 * @throws Exception if the elasticsearch API call is failing
 	 */
-	public static boolean isIndexExist(RestClient client, String index) throws Exception {
-		Response response = client.performRequest(new Request("HEAD", "/" + index));
-		return response.getStatusLine().getStatusCode() == 200;
+	public static boolean isIndexExist(RestClient client, final String index) throws Exception {
+		Response response = client.performRequest(new Request("GET", "/" + replaceIndexName(index)));
+
+		// Read the response as a String
+		String responseBody = new BufferedReader(new InputStreamReader(response.getEntity().getContent()))
+				.lines().reduce("", (accumulator, actual) -> accumulator + actual);
+		logger.trace("{}", responseBody);
+
+		// If we don't have an empty response ("{}"), then at least one index exists with the pattern
+		return !"{}".equals(responseBody);
 	}
 
 	/**

--- a/src/main/java/fr/pilato/elasticsearch/tools/util/ResourceList.java
+++ b/src/main/java/fr/pilato/elasticsearch/tools/util/ResourceList.java
@@ -270,4 +270,19 @@ public class ResourceList {
 
         return sortedFilenames;
     }
+
+    /**
+     * Replace index name from a form of "<my-index-{now/d}-000001>" to "my-index-{now/d}-*"
+     * @param indexName the index name to replace
+     * @return the replaced index name
+     */
+    public static String replaceIndexName(String indexName) {
+        logger.trace("replaceIndexName({})", indexName);
+        String replaced = indexName
+                .replaceAll("\\{[^}]*\\}", "*")
+                .replaceAll("<([^>]*)>", "$1")
+                .replaceAll("-\\d{6}", "-*");
+        logger.trace("/replaceIndexName({}) = [{}]", indexName, replaced);
+        return replaced;
+    }
 }

--- a/src/test/java/fr/pilato/elasticsearch/tools/ResourceListTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/tools/ResourceListTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.regex.Pattern;
 
+import static fr.pilato.elasticsearch.tools.util.ResourceList.replaceIndexName;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -48,6 +49,13 @@ public class ResourceListTest {
         String filename = "/Users/dpilato/Documents/Elasticsearch/dev/spring-elasticsearch/target/test-classes/es/twitter/_settings.json";
         Pattern pattern = Pattern.compile(".*/" + root + "/.*");
         assertThat(pattern.matcher(filename).matches(), is(true));
+    }
 
+    @Test
+    public void testIndexNames() {
+        assertThat(replaceIndexName("foo"), is("foo"));
+        assertThat(replaceIndexName("my-index-000001"), is("my-index-*"));
+        assertThat(replaceIndexName("<my-index-{now/d}>"), is("my-index-*"));
+        assertThat(replaceIndexName("<my-index-{now/d}-000001>"), is("my-index-*-*"));
     }
 }

--- a/src/test/resources/models/rollover-date-maths/%3Ctimeseries-%7Bnow%2Fd-2d%7D-000001%3E/_data/doc1.json
+++ b/src/test/resources/models/rollover-date-maths/%3Ctimeseries-%7Bnow%2Fd-2d%7D-000001%3E/_data/doc1.json
@@ -1,0 +1,3 @@
+{
+  "message": "message 1"
+}

--- a/src/test/resources/models/rollover-date-maths/%3Ctimeseries-%7Bnow%2Fd-2d%7D-000001%3E/_settings.json
+++ b/src/test/resources/models/rollover-date-maths/%3Ctimeseries-%7Bnow%2Fd-2d%7D-000001%3E/_settings.json
@@ -1,0 +1,7 @@
+{
+  "aliases": {
+    "timeseries": {
+      "is_write_index": true
+    }
+  }
+}

--- a/src/test/resources/models/rollover-simple/timeseries-000001/_data/doc1.json
+++ b/src/test/resources/models/rollover-simple/timeseries-000001/_data/doc1.json
@@ -1,0 +1,3 @@
+{
+  "message": "message 1"
+}

--- a/src/test/resources/models/rollover-simple/timeseries-000001/_settings.json
+++ b/src/test/resources/models/rollover-simple/timeseries-000001/_settings.json
@@ -1,0 +1,7 @@
+{
+  "aliases": {
+    "timeseries": {
+      "is_write_index": true
+    }
+  }
+}


### PR DESCRIPTION
ILM is using rollover behind the scene which can lead to indices from `index-000001` to be transformed to `index-000002`.
When the ILM has a DELETE phase, it might remove at some point the `index-000001` index.

And when we start again Beyonder, no new index should be created as we do have an index like `index-000002`.

Adding even more complexity, and index name can also use [date maths](https://www.elastic.co/guide/en/elasticsearch/reference/current/api-conventions.html#api-date-math-index-names), like `<logstash-{now/d-2d}-000001>`.

The index name might be first computed as `logstash-2025.03.03-000001` but then rolled over as `logstash-2025.03.03-000002`. After a day, it will become something like `logstash-2025.03.04-000001` and when rolled over: `logstash-2025.03.04-000002`.

This means that when we check if an index already exists, we need to transform some of the characters before checking if any index matches the wildcard:

* `logstash` we check `logstash`
* `logstash-000001` we check `logstash-*`
* `<logstash-{now/d-2d}>` we check `logstash-*`
* `<logstash-{now/d-2d}-000001>` we check `logstash-*-*`

Closes #354