### PR TITLE
URL Decode index names before replacing with wildcards

### DIFF
--- a/src/test/java/fr/pilato/elasticsearch/tools/BeyonderRestIT.java
+++ b/src/test/java/fr/pilato/elasticsearch/tools/BeyonderRestIT.java
@@ -625,11 +625,20 @@ public class BeyonderRestIT extends AbstractBeyonderTest {
         // Refresh the indices
         client.performRequest(new Request("POST", "/_refresh"));
 
-        // Check that we have 10 documents in my-index-* index because the daily index was not existing yet but only
-        // the yesterday index
-        Map<String, Object> response = asMap(client.performRequest(new Request("GET", "/my-index-*/_search")));
-        String numberOfHits = BeanUtils.getProperty(response, "hits.total.value");
-        assertThat(numberOfHits, equalTo("10"));
+        // Expected outcome is:
+        // Index from yesterday should exist but with no documents
+        {
+            Map<String, Object> response = asMap(client.performRequest(new Request("GET", "/%3Cmy-index-%7Bnow%2Fd-1d%7D%3E/_search")));
+            String numberOfHits = BeanUtils.getProperty(response, "hits.total.value");
+            assertThat(numberOfHits, equalTo("0"));
+        }
+
+        // Index from today should not have been created as we do have yet an older index with the same date math
+        {
+            Map<String, Object> response = asMap(client.performRequest(new Request("GET", "/my-index-*/_search")));
+            String numberOfHits = BeanUtils.getProperty(response, "hits.total.value");
+            assertThat(numberOfHits, equalTo("0"));
+        }
     }
 
     @Test

--- a/src/test/java/fr/pilato/elasticsearch/tools/ResourceListTest.java
+++ b/src/test/java/fr/pilato/elasticsearch/tools/ResourceListTest.java
@@ -53,9 +53,21 @@ public class ResourceListTest {
 
     @Test
     public void testIndexNames() {
+        // We test simple index names
         assertThat(replaceIndexName("foo"), is("foo"));
+        assertThat(replaceIndexName("foo-001"), is("foo-001"));
+        assertThat(replaceIndexName("000001-foo"), is("000001-foo"));
+
+        // We test rollover indices
         assertThat(replaceIndexName("my-index-000001"), is("my-index-*"));
+        assertThat(replaceIndexName("my-index-001234"), is("my-index-*"));
+
+        // We test date maths
         assertThat(replaceIndexName("<my-index-{now/d}>"), is("my-index-*"));
         assertThat(replaceIndexName("<my-index-{now/d}-000001>"), is("my-index-*-*"));
+
+        // The same but with URL encoded characters
+        assertThat(replaceIndexName("%3Cmy-index-%7Bnow%2Fd%7D%3E"), is("my-index-*"));
+        assertThat(replaceIndexName("%3Cmy-index-%7Bnow%2Fd%7D-000001%3E"), is("my-index-*-*"));
     }
 }


### PR DESCRIPTION
On disk, dirs might be URL encoded when using date maths indices. For example `<my-index-{now/d}-000001>` would be on written disk as `%3Cmy-index-%7Bnow%2Fd%7D-000001%3E`.

We need to first URL decode the filename before checking if we need to replace the index name with wildcards.

Closes #354.