### PR TITLE
Fix GPG signature when deploying

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,12 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>3.2.7</version>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
When using gpg > 2.1, we need to add some arguments:

```xml
<configuration>
  <keyname>${gpg.keyname}</keyname>
  <passphraseServerId>${gpg.keyname}</passphraseServerId>
  <gpgArguments>
    <arg>--pinentry-mode</arg>
    <arg>loopback</arg>
  </gpgArguments>
</configuration>
```

See https://central.sonatype.org/publish/publish-maven/#gpg-signed-components

Also if we end up seeing a message like:

> gpg: Note: database_open XYZ waiting for lock (held by XXXX)

We need to manually run:

```sh
rm ~/.gnupg/public-keys.d/pubring.db.lock
```
